### PR TITLE
add info on 2fa 

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,8 @@ git config --global user.username "buedaswag"
 git config --global user.name "Bueda Swag"
 ```
 
+**Optional Step 3:** If you **already have a Github account** and you have **2FA enabled**, you need an extra step and simply inputting your password will not work. In this case, you can go to https://github.com/settings/tokens, click on Generate new token. You can give it a name in the note field, we suggest you use ldsa-token. Then select repo in the scopes and click on Generate token. You will be prompted with a code that you should save (you will not be able to see it again after leaving that window). Now **use this code instead of your password [when cloning your repo](#14-clone-the-ds-prep-course-2021-repository)**.
+
 <br>
 
 ### **1.3 Setup your Workspace Repository**


### PR DESCRIPTION
This PR adds information for students who already have a Github account and have two factor authentication enabled. This was raised in #33 and #2.